### PR TITLE
Subtype config used as key defaultval

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/catalog/CatalogItem.java
+++ b/api/src/main/java/org/apache/brooklyn/api/catalog/CatalogItem.java
@@ -45,6 +45,7 @@ public interface CatalogItem<T,SpecT> extends BrooklynObject, Rebindable {
     
     public static enum CatalogItemType {
         TEMPLATE, 
+        APPLICATION,
         ENTITY, 
         POLICY,
         ENRICHER,
@@ -63,7 +64,7 @@ public interface CatalogItem<T,SpecT> extends BrooklynObject, Rebindable {
             if (Policy.class.isAssignableFrom(type)) return POLICY;
             if (Enricher.class.isAssignableFrom(type)) return ENRICHER;
             if (Location.class.isAssignableFrom(type)) return LOCATION;
-            if (Application.class.isAssignableFrom(type)) return TEMPLATE;
+            if (Application.class.isAssignableFrom(type)) return APPLICATION;
             if (Entity.class.isAssignableFrom(type)) return ENTITY;
             return null;
         }

--- a/api/src/main/java/org/apache/brooklyn/api/objs/BrooklynObjectType.java
+++ b/api/src/main/java/org/apache/brooklyn/api/objs/BrooklynObjectType.java
@@ -99,9 +99,10 @@ public enum BrooklynObjectType {
         switch (t) {
         case ENRICHER: return BrooklynObjectType.ENRICHER;
         case ENTITY: return BrooklynObjectType.ENTITY;
+        case APPLICATION: return BrooklynObjectType.ENTITY;
+        case TEMPLATE: return BrooklynObjectType.ENTITY;
         case LOCATION: return BrooklynObjectType.LOCATION;
         case POLICY: return BrooklynObjectType.POLICY;
-        case TEMPLATE: return BrooklynObjectType.ENTITY;
         default: return BrooklynObjectType.UNKNOWN;
         }
     }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigYamlTest.java
@@ -293,6 +293,8 @@ public class ConfigYamlTest extends AbstractYamlTest {
                 "    - $brooklyn:config(\"myOtherConf\")",
                 "    test.confSetPlain:",
                 "    - $brooklyn:config(\"myOtherConf\")",
+                "    test.confSetStringPlain:",
+                "    - $brooklyn:config(\"myOtherConf\")",
                 "    myOtherConf: myOther");
 
         final Entity app = createStartWaitAndLogApplication(yaml);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DslAndRebindYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DslAndRebindYamlTest.java
@@ -227,28 +227,26 @@ public class DslAndRebindYamlTest extends AbstractYamlRebindTest {
         //          <sensorName>foo</sensorName>
         //        </org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent_-AttributeWhenReady>
         //      </test.confName>
+        
         // may be longer if there is a constraint, inheritance, esp if it is a BasicConfigKeyOverwriting storing the parent's definition also, eg
+        // (with some cleanups now since 2018-11 the BasicConfigKey will prefer nulls for lesser-used fields with common default values)
 //      <org.apache.brooklyn.core.config.BasicConfigKey_-BasicConfigKeyOverwriting>
 //        <name>test.confName</name>
-//        <deprecatedNames class="ImmutableList" reference="../../../../searchPath"/>
 //        <type>java.lang.String</type>
 //        <description>Configuration key, my name</description>
 //        <defaultValue class="org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent$AttributeWhenReady" reference="../../../../config/test.confName/org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent_-AttributeWhenReady"/>
 //        <reconfigurable>false</reconfigurable>
-//        <constraint class="com.google.common.base.Predicates$ObjectPredicate">ALWAYS_TRUE</constraint>
 //        <parentKey class="configKey">
 //          <name>test.confName</name>
-//          <deprecatedNames class="ImmutableList" reference="../../../../../searchPath"/>
 //          <type>java.lang.String</type>
 //          <description>Configuration key, my name</description>
 //          <defaultValue class="string">defaultval</defaultValue>
 //          <reconfigurable>false</reconfigurable>
-//          <constraint class="com.google.common.base.Predicates$ObjectPredicate">ALWAYS_TRUE</constraint>
 //        </parentKey>
 //      </org.apache.brooklyn.core.config.BasicConfigKey_-BasicConfigKeyOverwriting>
         
 
-        Assert.assertTrue(testConfNamePersistedState.length() < 1600, "persisted state too long ("+testConfNamePersistedState.length()+"): " + testConfNamePersistedState);
+        Assert.assertTrue(testConfNamePersistedState.length() < 1200, "persisted state too long ("+testConfNamePersistedState.length()+"): " + testConfNamePersistedState);
         
         Assert.assertFalse(testConfNamePersistedState.contains("bar"), "value 'bar' leaked in persisted state");
     }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DslAndRebindYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DslAndRebindYamlTest.java
@@ -227,8 +227,28 @@ public class DslAndRebindYamlTest extends AbstractYamlRebindTest {
         //          <sensorName>foo</sensorName>
         //        </org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent_-AttributeWhenReady>
         //      </test.confName>
+        // may be longer if there is a constraint, inheritance, esp if it is a BasicConfigKeyOverwriting storing the parent's definition also, eg
+//      <org.apache.brooklyn.core.config.BasicConfigKey_-BasicConfigKeyOverwriting>
+//        <name>test.confName</name>
+//        <deprecatedNames class="ImmutableList" reference="../../../../searchPath"/>
+//        <type>java.lang.String</type>
+//        <description>Configuration key, my name</description>
+//        <defaultValue class="org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent$AttributeWhenReady" reference="../../../../config/test.confName/org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent_-AttributeWhenReady"/>
+//        <reconfigurable>false</reconfigurable>
+//        <constraint class="com.google.common.base.Predicates$ObjectPredicate">ALWAYS_TRUE</constraint>
+//        <parentKey class="configKey">
+//          <name>test.confName</name>
+//          <deprecatedNames class="ImmutableList" reference="../../../../../searchPath"/>
+//          <type>java.lang.String</type>
+//          <description>Configuration key, my name</description>
+//          <defaultValue class="string">defaultval</defaultValue>
+//          <reconfigurable>false</reconfigurable>
+//          <constraint class="com.google.common.base.Predicates$ObjectPredicate">ALWAYS_TRUE</constraint>
+//        </parentKey>
+//      </org.apache.brooklyn.core.config.BasicConfigKey_-BasicConfigKeyOverwriting>
+        
 
-        Assert.assertTrue(testConfNamePersistedState.length() < 400, "persisted state too long: " + testConfNamePersistedState);
+        Assert.assertTrue(testConfNamePersistedState.length() < 1600, "persisted state too long ("+testConfNamePersistedState.length()+"): " + testConfNamePersistedState);
         
         Assert.assertFalse(testConfNamePersistedState.contains("bar"), "value 'bar' leaked in persisted state");
     }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -261,9 +261,9 @@
                         </goals>
                         <configuration>
                             <compilerId>groovy-eclipse-compiler</compilerId>
-                            <includes>
+                            <testIncludes>
                               <include>**/*.groovy</include>
-                            </includes>
+                            </testIncludes>
                             <fork>true</fork>
                             <verbose>false</verbose>
                             <source>${java.version}</source>

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/CatalogPredicates.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/CatalogPredicates.java
@@ -141,8 +141,10 @@ public class CatalogPredicates {
 
     public static final Predicate<CatalogItem<Application,EntitySpec<? extends Application>>> IS_TEMPLATE = 
             CatalogPredicates.<Application,EntitySpec<? extends Application>>isCatalogItemType(CatalogItemType.TEMPLATE);
+    public static final Predicate<CatalogItem<Entity,EntitySpec<?>>> IS_APPLICATION = 
+        CatalogPredicates.<Entity,EntitySpec<?>>isCatalogItemType(CatalogItemType.APPLICATION);
     public static final Predicate<CatalogItem<Entity,EntitySpec<?>>> IS_ENTITY = 
-            CatalogPredicates.<Entity,EntitySpec<?>>isCatalogItemType(CatalogItemType.ENTITY);
+        CatalogPredicates.<Entity,EntitySpec<?>>isCatalogItemType(CatalogItemType.ENTITY);
     public static final Predicate<CatalogItem<Policy,PolicySpec<?>>> IS_POLICY = 
             CatalogPredicates.<Policy,PolicySpec<?>>isCatalogItemType(CatalogItemType.POLICY);
     public static final Predicate<CatalogItem<Enricher,EnricherSpec<?>>> IS_ENRICHER =

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -954,6 +954,9 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
 
             if (itemType==CatalogItemType.TEMPLATE) {
                 tags.add(BrooklynTags.CATALOG_TEMPLATE);
+                itemType = CatalogItemType.APPLICATION;
+            }
+            if (itemType==CatalogItemType.APPLICATION) {
                 itemType = CatalogItemType.ENTITY;
                 superTypes.add(Application.class);
             }
@@ -1371,7 +1374,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
             } catch (Exception e) {
                 Exceptions.propagateIfFatal(e);
                 // record the error if we have reason to expect this guess to succeed
-                if (item.containsKey("services") && (candidateCiType==CatalogItemType.ENTITY || candidateCiType==CatalogItemType.TEMPLATE)) {
+                if (item.containsKey("services") && (candidateCiType==CatalogItemType.ENTITY || candidateCiType==CatalogItemType.APPLICATION || candidateCiType==CatalogItemType.TEMPLATE)) {
                     // explicit services supplied, so plan should have been parseable for an entity or a a service
                     errors.add(e);
                 } else if (catalogItemType!=null && key!=null) {
@@ -2079,6 +2082,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
                 dto.setSymbolicName(dto.getJavaType());
                 switch (dto.getCatalogItemType()) {
                     case TEMPLATE:
+                    case APPLICATION:
                     case ENTITY:
                         dto.setPlanYaml("services: [{ type: "+dto.getJavaType()+" }]");
                         break;

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogApplicationItemDto.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogApplicationItemDto.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.catalog.internal;
+
+import org.apache.brooklyn.api.entity.Application;
+import org.apache.brooklyn.api.entity.EntitySpec;
+
+public class CatalogApplicationItemDto extends CatalogItemDtoAbstract<Application,EntitySpec<? extends Application>> {
+
+    @Override
+    public CatalogItemType getCatalogItemType() {
+        return CatalogItemType.APPLICATION;
+    }
+
+    @Override
+    public Class<Application> getCatalogItemJavaType() {
+        return Application.class;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    public Class<EntitySpec<? extends Application>> getSpecType() {
+        return (Class)EntitySpec.class;
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemBuilder.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemBuilder.java
@@ -33,6 +33,7 @@ public class CatalogItemBuilder<CIConcreteType extends CatalogItemDtoAbstract<?,
         Preconditions.checkNotNull(itemType, "itemType required");
         switch (itemType) {
         case ENTITY: return newEntity(symbolicName, version);
+        case APPLICATION: return newApplication(symbolicName, version);
         case TEMPLATE: return newTemplate(symbolicName, version);
         case POLICY: return newPolicy(symbolicName, version);
         case ENRICHER: return newEnricher(symbolicName, version);
@@ -43,6 +44,12 @@ public class CatalogItemBuilder<CIConcreteType extends CatalogItemDtoAbstract<?,
 
     public static CatalogItemBuilder<CatalogEntityItemDto> newEntity(String symbolicName, String version) {
         return new CatalogItemBuilder<CatalogEntityItemDto>(new CatalogEntityItemDto())
+                .symbolicName(symbolicName)
+                .version(version);
+    }
+
+    public static CatalogItemBuilder<CatalogApplicationItemDto> newApplication(String symbolicName, String version) {
+        return new CatalogItemBuilder<CatalogApplicationItemDto>(new CatalogApplicationItemDto())
                 .symbolicName(symbolicName)
                 .version(version);
     }

--- a/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
@@ -39,6 +39,7 @@ import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.core.task.ValueResolver;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.TypeTokens;
+import org.apache.brooklyn.util.javalang.JavaClassNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -475,6 +476,26 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
         
         public ConfigKey<T> getParentKey() {
             return parentKey;
+        }
+        
+        @Override
+        public T extractValue(Map<?, ?> vals, ExecutionContext exec) {
+            // if we are unsure and want to log both, then
+            T v1, v2 = null;
+            if (parentKey instanceof BasicConfigKey<?>) {
+                v2 = ((BasicConfigKey<T>)parentKey).extractValue(vals, exec);
+                return v2;
+            }
+            v1 = super.extractValue(vals, exec);
+            // uncomment the "return v2" above, and these lines below, if we want to reenable reporting
+            // of cases where these values are different.  based on spot-checks and thinking it through,
+            // i (alex) think v2 is always correct if applicable, but leaving this in for a while after 2018-11
+            // in case it warrants further investigation.
+//            if (v2!=null && !Objects.equal(v1, v2)) {
+//                log.warn("Different values extracted for "+this+": "+v1+" ("+JavaClassNames.cleanSimpleClassName(v1)+") / "+v2+" ("+JavaClassNames.cleanSimpleClassName(v2)+")");
+//                return v2;
+//            }
+            return v1;
         }
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
@@ -490,13 +490,21 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
         public ConfigKey<T> getParentKey() {
             return parentKey;
         }
+
+        @Override
+        public boolean isSet(Map<?,?> vals) {
+            if (parentKey instanceof ConfigKeySelfExtracting<?>) {
+                return ((ConfigKeySelfExtracting<T>)parentKey).isSet(vals);
+            }
+            return super.isSet(vals);
+        }
         
         @Override
         public T extractValue(Map<?, ?> vals, ExecutionContext exec) {
             // if we are unsure and want to log both, then
             T v1, v2 = null;
-            if (parentKey instanceof BasicConfigKey<?>) {
-                v2 = ((BasicConfigKey<T>)parentKey).extractValue(vals, exec);
+            if (parentKey instanceof ConfigKeySelfExtracting<?>) {
+                v2 = ((ConfigKeySelfExtracting<T>)parentKey).extractValue(vals, exec);
                 return v2;
             }
             v1 = super.extractValue(vals, exec);

--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -356,7 +356,8 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
     }
 
     /**
-     * @deprecated since 0.7.0; only used for legacy brooklyn types where constructor is called directly
+     * @deprecated since 0.7.0; only used for legacy brooklyn types where constructor is called directly,
+     * (and used for internal private configuration from entity specs which use flags to set keys)
      */
     @Override
     @Deprecated

--- a/core/src/main/java/org/apache/brooklyn/core/location/internal/LocationConfigMap.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/internal/LocationConfigMap.java
@@ -89,7 +89,7 @@ public class LocationConfigMap extends AbstractConfigMapImpl<Location> {
     }
 
     @Override
-    protected Object coerceConfigVal(ConfigKey<?> key, Object v) {
+    protected Object coerceConfigValOnWrite(ConfigKey<?> key, Object v) {
         if ((Class.class.isAssignableFrom(key.getType()) || Function.class.isAssignableFrom(key.getType())) && v instanceof String) {
             // strings can be written where classes/functions are permitted; 
             // this because an occasional pattern only for locations because validation wasn't enforced there
@@ -98,7 +98,7 @@ public class LocationConfigMap extends AbstractConfigMapImpl<Location> {
             return v;
         }
         
-        return super.coerceConfigVal(key, v);
+        return super.coerceConfigValOnWrite(key, v);
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/aggregator/AggregationJob.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/aggregator/AggregationJob.java
@@ -52,7 +52,7 @@ public final class AggregationJob implements Runnable {
 
     public static BasicAttributeSensorAndConfigKey<List<Map<String, String>>> DASHBOARD_POLICY_HIGHLIGHTS = new BasicAttributeSensorAndConfigKey(List.class,
             "dashboard.policyHighlights",
-            "Highlights from policies. List of Masps, where each map should contain text and category");
+            "Highlights from policies. List of Maps, where each map should contain text and category");
 
     private final Entity entity;
 

--- a/core/src/test/java/org/apache/brooklyn/core/plan/XmlPlanToSpecTransformer.java
+++ b/core/src/test/java/org/apache/brooklyn/core/plan/XmlPlanToSpecTransformer.java
@@ -84,7 +84,7 @@ public class XmlPlanToSpecTransformer implements PlanToSpecTransformer {
         if (item.getCatalogItemType()==CatalogItemType.ENTITY) {
             return (SpecT)toEntitySpec(parseXml(item.getPlanYaml()), 1);
         }
-        if (item.getCatalogItemType()==CatalogItemType.TEMPLATE) {
+        if (item.getCatalogItemType()==CatalogItemType.TEMPLATE || item.getCatalogItemType()==CatalogItemType.APPLICATION) {
             return (SpecT)toEntitySpec(parseXml(item.getPlanYaml()), 0);
         }
         throw new UnsupportedTypePlanException("Type "+item.getCatalogItemType()+" not supported");

--- a/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntity.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntity.java
@@ -67,6 +67,7 @@ public interface TestEntity extends Entity, Startable, EntityLocal, EntityIntern
     public static final BasicConfigKey<Map> CONF_MAP_PLAIN = new BasicConfigKey<Map>(Map.class, "test.confMapPlain", "Configuration key that's a plain map", ImmutableMap.of());
     public static final BasicConfigKey<List> CONF_LIST_PLAIN = new BasicConfigKey<List>(List.class, "test.confListPlain", "Configuration key that's a plain list", ImmutableList.of());
     public static final BasicConfigKey<Set> CONF_SET_PLAIN = new BasicConfigKey<Set>(Set.class, "test.confSetPlain", "Configuration key that's a plain set", ImmutableSet.of());
+    public static final BasicConfigKey<Set<String>> CONF_SET_STRING_PLAIN = new BasicConfigKey<Set<String>>(new TypeToken<Set<String>>() {}, "test.confSetStringPlain", "Configuration key that's a plain set of strings", ImmutableSet.of());
     public static final MapConfigKey<String> CONF_MAP_THING = new MapConfigKey<String>(String.class, "test.confMapThing", "Configuration key that's a map thing");
     public static final MapConfigKey<Object> CONF_MAP_OBJ_THING = new MapConfigKey<Object>(Object.class, "test.confMapObjThing", "Configuration key that's a map thing with objects");
     public static final ListConfigKey<String> CONF_LIST_THING = new ListConfigKey<String>(String.class, "test.confListThing", "Configuration key that's a list thing");

--- a/core/src/test/java/org/apache/brooklyn/util/core/osgi/OsgiTestBase.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/osgi/OsgiTestBase.java
@@ -28,6 +28,8 @@ import org.apache.commons.io.FileUtils;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.launch.Framework;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
@@ -36,6 +38,8 @@ import org.testng.annotations.BeforeMethod;
  * @author Ciprian Ciubotariu <cheepeero@gmx.net>
  */
 public class OsgiTestBase {
+
+    private static final Logger log = LoggerFactory.getLogger(OsgiTestBase.class);
 
     public static final String BROOKLYN_OSGI_TEST_A_0_1_0_PATH = OsgiTestResources.BROOKLYN_OSGI_TEST_A_0_1_0_PATH;
     public static final String BROOKLYN_OSGI_TEST_A_0_1_0_URL = "classpath:"+BROOKLYN_OSGI_TEST_A_0_1_0_PATH;
@@ -75,7 +79,11 @@ public class OsgiTestBase {
         Osgis.ungetFramework(framework);
         framework = null;
         if (storageTempDir != null) {
-            FileUtils.deleteDirectory(storageTempDir);
+            try {
+                FileUtils.deleteDirectory(storageTempDir);
+            } catch (IOException e) {
+                log.warn(e.getMessage());
+            }
             storageTempDir = null;
         }
     }

--- a/core/src/test/java/org/apache/brooklyn/util/core/osgi/OsgiTestBase.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/osgi/OsgiTestBase.java
@@ -38,8 +38,6 @@ import org.testng.annotations.BeforeMethod;
  */
 public class OsgiTestBase {
 
-    private static final Logger log = LoggerFactory.getLogger(OsgiTestBase.class);
-
     public static final String BROOKLYN_OSGI_TEST_A_0_1_0_PATH = OsgiTestResources.BROOKLYN_OSGI_TEST_A_0_1_0_PATH;
     public static final String BROOKLYN_OSGI_TEST_A_0_1_0_URL = "classpath:"+BROOKLYN_OSGI_TEST_A_0_1_0_PATH;
 

--- a/core/src/test/java/org/apache/brooklyn/util/core/osgi/OsgiTestBase.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/osgi/OsgiTestBase.java
@@ -16,15 +16,14 @@
 package org.apache.brooklyn.util.core.osgi;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
 import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.io.FileUtil;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.osgi.OsgiTestResources;
-import org.apache.commons.io.FileUtils;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.launch.Framework;
@@ -44,7 +43,7 @@ public class OsgiTestBase {
     public static final String BROOKLYN_OSGI_TEST_A_0_1_0_PATH = OsgiTestResources.BROOKLYN_OSGI_TEST_A_0_1_0_PATH;
     public static final String BROOKLYN_OSGI_TEST_A_0_1_0_URL = "classpath:"+BROOKLYN_OSGI_TEST_A_0_1_0_PATH;
 
-    protected Bundle install(String url) throws BundleException {
+    protected Bundle install(String url) {
         try {
             return Osgis.install(framework, url);
         } catch (Exception e) {
@@ -52,7 +51,7 @@ public class OsgiTestBase {
         }
     }
 
-    protected Bundle installFromClasspath(String resourceName) throws BundleException {
+    protected Bundle installFromClasspath(String resourceName) {
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), resourceName);
         try {
             return Osgis.install(framework, String.format("classpath:%s", resourceName));
@@ -71,21 +70,13 @@ public class OsgiTestBase {
     }
 
     @AfterMethod(alwaysRun = true)
-    public void tearDown() throws BundleException, IOException, InterruptedException {
+    public void tearDown() {
         tearDownOsgiFramework(framework, storageTempDir);
     }
 
-    public static void tearDownOsgiFramework(Framework framework, File storageTempDir) throws BundleException, InterruptedException, IOException {
+    public static void tearDownOsgiFramework(Framework framework, File storageTempDir) {
         Osgis.ungetFramework(framework);
-        framework = null;
-        if (storageTempDir != null) {
-            try {
-                FileUtils.deleteDirectory(storageTempDir);
-            } catch (IOException e) {
-                log.warn(e.getMessage());
-            }
-            storageTempDir = null;
-        }
+        FileUtil.deleteDirectory(storageTempDir);
     }
 
     public static void preinstallLibrariesLowLevelToPreventCatalogBomParsing(ManagementContext mgmt, String ...libraries) {

--- a/core/src/test/java/org/apache/brooklyn/util/core/ssh/BashCommandsIntegrationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/ssh/BashCommandsIntegrationTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.test.DisableOnWindows;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.core.task.BasicExecutionContext;
 import org.apache.brooklyn.util.core.task.ssh.SshTasks;
@@ -133,6 +134,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
     
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs a bash shell available on localhost")
     public void testRemoveRequireTtyFromSudoersFile() throws Exception {
         String cmds = BashCommands.dontRequireTtyForSudo();
 
@@ -154,6 +156,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
     
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs a whoami command available on localhost")
     public void testSudo() throws Exception {
         ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         ByteArrayOutputStream errStream = new ByteArrayOutputStream();
@@ -177,6 +180,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
     
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs a bash shell available on localhost")
     public void testDownloadFirstSuccessfulFile() throws Exception {
         List<String> cmds = BashCommands.commandsToDownloadUrlsAs(
                 ImmutableList.of(sourceNonExistantFileUrl, sourceFileUrl1, sourceFileUrl2), 
@@ -188,6 +192,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
     
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs an ssh server listening on port 22 on localhost")
     public void testDownloadToStdout() throws Exception {
         ProcessTaskWrapper<String> t = SshTasks.newSshExecTaskFactory(loc, 
                 "cd "+destFile.getParentFile().getAbsolutePath(),
@@ -199,6 +204,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
 
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs an ssh server listening on port 22 on localhost")
     public void testAlternativesWhereFirstSucceeds() throws Exception {
         ProcessTaskWrapper<Integer> t = SshTasks.newSshExecTaskFactory(loc)
                 .add(BashCommands.alternatives(Arrays.asList("echo first", "exit 88")))
@@ -213,6 +219,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
 
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs an ssh server listening on port 22 on localhost")
     public void testAlternatives() throws Exception {
         ProcessTaskWrapper<Integer> t = SshTasks.newSshExecTaskFactory(loc)
                 .add(BashCommands.alternatives(Arrays.asList("asdfj_no_such_command_1", "exit 88")))
@@ -224,6 +231,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
 
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs an ssh server listening on port 22 on localhost")
     public void testRequireTestHandlesFailure() throws Exception {
         ProcessTaskWrapper<?> t = SshTasks.newSshExecTaskFactory(loc)
             .add(BashCommands.requireTest("-f "+sourceNonExistantFile.getPath(),
@@ -236,6 +244,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
 
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs an ssh server listening on port 22 on localhost")
     public void testRequireTestHandlesSuccess() throws Exception {
         ProcessTaskWrapper<?> t = SshTasks.newSshExecTaskFactory(loc)
             .add(BashCommands.requireTest("-f "+sourceFile1.getPath(),
@@ -247,6 +256,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
 
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs an ssh server listening on port 22 on localhost")
     public void testRequireFileHandlesFailure() throws Exception {
         ProcessTaskWrapper<?> t = SshTasks.newSshExecTaskFactory(loc)
             .add(BashCommands.requireFile(sourceNonExistantFile.getPath())).newTask();
@@ -260,6 +270,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
 
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs an ssh server listening on port 22 on localhost")
     public void testRequireFileHandlesSuccess() throws Exception {
         ProcessTaskWrapper<?> t = SshTasks.newSshExecTaskFactory(loc)
             .add(BashCommands.requireFile(sourceFile1.getPath())).newTask();
@@ -270,6 +281,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
 
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs an ssh server listening on port 22 on localhost")
     public void testRequireFailureExitsImmediately() throws Exception {
         ProcessTaskWrapper<?> t = SshTasks.newSshExecTaskFactory(loc)
             .add(BashCommands.requireTest("-f "+sourceNonExistantFile.getPath(),
@@ -284,6 +296,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
 
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs a bash shell available on localhost")
     public void testPipeMultiline() throws Exception {
         String output = execRequiringZeroAndReturningStdout(loc,
                 BashCommands.pipeTextTo("hello world\n"+"and goodbye\n", "wc")).get();
@@ -292,6 +305,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
 
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs a bash shell available on localhost")
     public void testWaitForFileContentsWhenAbortingOnFail() throws Exception {
         String fileContent = "mycontents";
         String cmd = BashCommands.waitForFileContents(destFile.getAbsolutePath(), fileContent, Duration.ONE_SECOND, true);
@@ -305,6 +319,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
 
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs a bash shell available on localhost")
     public void testWaitForFileContentsWhenNotAbortingOnFail() throws Exception {
         String fileContent = "mycontents";
         String cmd = BashCommands.waitForFileContents(destFile.getAbsolutePath(), fileContent, Duration.ONE_SECOND, false);
@@ -318,6 +333,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
     
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs a bash shell available on localhost")
     public void testWaitForFileContentsWhenContentsAppearAfterStart() throws Exception {
         String fileContent = "mycontents";
 
@@ -335,6 +351,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
     
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs a bash shell available on localhost")
     public void testWaitForFileExistsWhenAbortingOnFail() throws Exception {
         String cmd = BashCommands.waitForFileExists(destFile.getAbsolutePath(), Duration.ONE_SECOND, true);
 
@@ -347,6 +364,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
 
     @Test(groups="Integration")
+    @DisableOnWindows(reason = "Needs a bash shell available on localhost")
     public void testWaitForFileExistsWhenNotAbortingOnFail() throws Exception {
         String cmd = BashCommands.waitForFileExists(destFile.getAbsolutePath(), Duration.ONE_SECOND, false);
 
@@ -359,6 +377,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
     
     @Test(groups="Integration", dependsOnMethods="testSudo")
+    @DisableOnWindows(reason = "Needs a bash shell available on localhost")
     public void testWaitForPortFreeWhenAbortingOnTimeout() throws Exception {
         ServerSocket serverSocket = openServerSocket();
         try {
@@ -378,6 +397,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
 
     @Test(groups="Integration", dependsOnMethods="testSudo")
+    @DisableOnWindows(reason = "Needs a bash shell available on localhost")
     public void testWaitForPortFreeWhenNotAbortingOnTimeout() throws Exception {
         ServerSocket serverSocket = openServerSocket();
         try {
@@ -397,6 +417,7 @@ public class BashCommandsIntegrationTest extends BrooklynMgmtUnitTestSupport {
     }
     
     @Test(groups="Integration", dependsOnMethods="testSudo")
+    @DisableOnWindows(reason = "Needs a bash shell available on localhost")
     public void testWaitForPortFreeWhenFreedAfterStart() throws Exception {
         ServerSocket serverSocket = openServerSocket();
         try {

--- a/core/src/test/resources/org/apache/brooklyn/core/mgmt/rebind/config-inheritance-basic-2016-11-kmpez5fznt-out
+++ b/core/src/test/resources/org/apache/brooklyn/core/mgmt/rebind/config-inheritance-basic-2016-11-kmpez5fznt-out
@@ -18,7 +18,7 @@ under the License.
 -->
 
 <entity>
-  <brooklynVersion>0.10.0-SNAPSHOT</brooklynVersion>
+  <brooklynVersion>$VERSION</brooklynVersion>
   <type>org.apache.brooklyn.core.test.entity.TestApplicationNoEnrichersImpl</type>
   <id>kmpez5fznt</id>
   <displayName>TestApplicationNoEnrichersImpl:kmpe</displayName>
@@ -39,7 +39,6 @@ under the License.
         <type>java.lang.String</type>
         <reconfigurable>false</reconfigurable>
         <runtimeInheritance class="org.apache.brooklyn.core.config.BasicConfigInheritance$NeverInherited"/>
-        <constraint class="com.google.common.base.Predicates$ObjectPredicate">ALWAYS_TRUE</constraint>
       </configKey>
     </key1>
   </configKeys>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1110,6 +1110,7 @@
                   <exclude>**/src/main/license/**</exclude>
                   <exclude>**/src/test/license/**</exclude>
                   <exclude>**/MANIFEST.MF</exclude>
+                  <exclude>**/META-INF/services/**</exclude>
                   <exclude>**/test-output/**</exclude>
                   <exclude>**/*.pem.pub</exclude>
                   <exclude>**/*.pem</exclude>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1385,6 +1385,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${surefire.version}</version>
                         <configuration>
+                            <useSystemClassLoader>false</useSystemClassLoader>
                             <properties>
                                 <property>
                                     <name>listener</name>

--- a/policy/src/main/java/org/apache/brooklyn/policy/failover/PropagatePrimaryEnricher.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/failover/PropagatePrimaryEnricher.java
@@ -90,6 +90,7 @@ public class PropagatePrimaryEnricher extends AbstractEnricher implements Sensor
             Collection<? extends Sensor<?>> sensorsToRemove = config().get(PROPAGATING);
             if (sensorsToRemove!=null) {
                 for (Sensor<?> s: sensorsToRemove) {
+                    // TODO - allow strings above also
                     if (s instanceof AttributeSensor) {
                         ((EntityInternal)entity).sensors().remove((AttributeSensor<?>)s);
                     }
@@ -119,7 +120,7 @@ public class PropagatePrimaryEnricher extends AbstractEnricher implements Sensor
         
         Collection<? extends Sensor<?>> sensorsToPropagate = getConfig(PROPAGATING);
         if (sensorsToPropagate==null || sensorsToPropagate.isEmpty()) {
-            log.warn("");
+            log.warn("Nothing found to propagate from primary "+primary+" at "+entity);
             return;
         }
         spec.configure(Propagator.PROPAGATING, sensorsToPropagate);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
@@ -294,6 +294,7 @@ public class CatalogTransformer {
         try {
             switch (item.getCatalogItemType()) {
             case TEMPLATE:
+            case APPLICATION:
             case ENTITY:
                 return catalogEntitySummary(b, item, ub);
             case POLICY:
@@ -369,6 +370,7 @@ public class CatalogTransformer {
         String itemId = item.getId();
         switch (item.getCatalogItemType()) {
         case TEMPLATE:
+        case APPLICATION:
             return serviceUriBuilder(ub, CatalogApi.class, "getApplication").build(itemId, item.getVersion());
         case ENTITY:
             return serviceUriBuilder(ub, CatalogApi.class, "getEntity").build(itemId, item.getVersion());

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/TypeTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/TypeTransformer.java
@@ -23,6 +23,7 @@ import static org.apache.brooklyn.rest.util.WebResourceUtils.serviceUriBuilder;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -87,7 +88,11 @@ public class TypeTransformer {
             result.setExtraField("template", true);
         }
         if (item.getIconUrl()!=null) {
-            result.setIconUrl(tidyIconLink(b, item, item.getIconUrl(), ub));
+            String tidiedUrl = tidyIconLink(b, item, item.getIconUrl(), ub);
+            result.setIconUrl(tidiedUrl);
+            if (!Objects.equals(item.getIconUrl(), tidiedUrl)) {
+                result.setExtraField("iconUrlSource", item.getIconUrl());
+            }
         }
         
         if (detail) {

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/ItemLister.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/ItemLister.java
@@ -239,7 +239,7 @@ public class ItemLister {
                         Map<String,Object> itemDescriptor = ItemDescriptors.toItemDescriptor(catalog, item, headingsOnly);
 
                         itemCount++;
-                        if (item.getCatalogItemType() == CatalogItem.CatalogItemType.ENTITY || item.getCatalogItemType() == CatalogItem.CatalogItemType.TEMPLATE) {
+                        if (item.getCatalogItemType() == CatalogItem.CatalogItemType.ENTITY || item.getCatalogItemType() == CatalogItem.CatalogItemType.TEMPLATE || item.getCatalogItemType() == CatalogItem.CatalogItemType.APPLICATION) {
                             entities.add(itemDescriptor);
                         } else if (item.getCatalogItemType() == CatalogItem.CatalogItemType.POLICY) {
                             policies.add(itemDescriptor);

--- a/test-support/src/main/java/org/apache/brooklyn/test/DisableOnWindows.java
+++ b/test-support/src/main/java/org/apache/brooklyn/test/DisableOnWindows.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.test;
+
+import java.lang.annotation.*;
+
+/**
+ * Used to indicate that a test should ne be executed on Windows.
+ *
+ * <p>You must add the following to the class where this annotation is being used:
+ * {@code @Listeners(DisableOnWindows)}</p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Documented
+public @interface DisableOnWindows {
+
+    /**3
+     * Explain the reason for the test being disabled.
+     *
+     * <p>e.g. "Needs an ssh server listening on port 22 on localhost."</p>
+     */
+    String reason();
+}

--- a/test-support/src/main/java/org/apache/brooklyn/test/DisableOnWindowsListener.java
+++ b/test-support/src/main/java/org/apache/brooklyn/test/DisableOnWindowsListener.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.test;
+
+import org.apache.brooklyn.util.os.Os;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.IAnnotationTransformer;
+import org.testng.annotations.ITestAnnotation;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+/**
+ * Scans all tests annotated with {@link DisableOnWindows} and, on Windows, sets {@code enabled=false} if the current
+ * environment is Windows..
+ */
+public class DisableOnWindowsListener implements IAnnotationTransformer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DisableOnWindowsListener.class);
+
+    @Override
+    public void transform(
+            final ITestAnnotation annotation,
+            final Class testClass,
+            final Constructor testConstructor,
+            final Method testMethod
+    ) {
+        if (testMethod != null ) {
+            final DisableOnWindows disableOnWindows = testMethod.getAnnotation(DisableOnWindows.class);
+            if (disableOnWindows != null && Os.isMicrosoftWindows()) {
+                annotation.setEnabled(false);
+                LOG.info(String.format("Disabled: %s.%s - %s",
+                        testMethod.getDeclaringClass().getName(),
+                        testMethod.getName(),
+                        disableOnWindows.reason()));
+            }
+        }
+    }
+
+}

--- a/test-support/src/main/resources/META-INF/services/org.testng.ITestNGListener
+++ b/test-support/src/main/resources/META-INF/services/org.testng.ITestNGListener
@@ -1,0 +1,1 @@
+org.apache.brooklyn.test.DisableOnWindowsListener

--- a/test-support/src/test/java/org/apache/brooklyn/test/DisableOnWindowsTest.java
+++ b/test-support/src/test/java/org/apache/brooklyn/test/DisableOnWindowsTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.test;
+
+import org.apache.brooklyn.util.os.Os;
+import org.testng.annotations.Test;
+
+import static org.apache.brooklyn.test.Asserts.assertTrue;
+import static org.apache.brooklyn.test.Asserts.fail;
+
+public class DisableOnWindowsTest {
+
+    @Test
+    public void alwaysRun() {
+        assertTrue(true);
+    }
+
+    @Test
+    @DisableOnWindows(reason = "unit test")
+    public void isDisabledOnWindows() {
+        if (Os.isMicrosoftWindows()) {
+            fail("Test should have been disabled on windows");
+        }
+    }
+}

--- a/utils/common/src/main/java/org/apache/brooklyn/util/io/FileUtil.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/io/FileUtil.java
@@ -184,4 +184,21 @@ public class FileUtil {
         }
         return file.createNewFile();
     }
+
+    /**
+     * Recursively delete a directory.
+     *
+     * <p>Any IOException that might be raised is logged and not thrown.</p>
+     *
+     * @param file The directory to be deleted
+     */
+    public static void deleteDirectory(final File file) {
+        if (file != null) {
+            try {
+                FileUtils.deleteDirectory(file);
+            } catch (IOException e) {
+                LOG.warn(e.getMessage());
+            }
+        }
+    }
 }

--- a/utils/rt-felix/src/test/java/org/apache/brooklyn/rt/felix/EmbeddedFelixFrameworkTest.java
+++ b/utils/rt-felix/src/test/java/org/apache/brooklyn/rt/felix/EmbeddedFelixFrameworkTest.java
@@ -66,7 +66,11 @@ public class EmbeddedFelixFrameworkTest {
         EmbeddedFelixFramework.stopFramework(framework);
         framework = null;
         if (storageTempDir != null) {
-            FileUtils.deleteDirectory(storageTempDir);
+            try {
+                FileUtils.deleteDirectory(storageTempDir);
+            } catch (IOException e) {
+                log.warn(e.getMessage());
+            }
             storageTempDir = null;
         }
     }

--- a/utils/rt-felix/src/test/java/org/apache/brooklyn/rt/felix/EmbeddedFelixFrameworkTest.java
+++ b/utils/rt-felix/src/test/java/org/apache/brooklyn/rt/felix/EmbeddedFelixFrameworkTest.java
@@ -16,7 +16,6 @@
 package org.apache.brooklyn.rt.felix;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Enumeration;
@@ -25,11 +24,10 @@ import java.util.jar.JarInputStream;
 
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
 import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.io.FileUtil;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.osgi.OsgiTestResources;
 import org.apache.brooklyn.util.stream.Streams;
-import org.apache.commons.io.FileUtils;
-import org.osgi.framework.BundleException;
 import org.osgi.framework.launch.Framework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,21 +56,13 @@ public class EmbeddedFelixFrameworkTest {
     }
 
     @AfterMethod(alwaysRun = true)
-    public void tearDown() throws BundleException, IOException, InterruptedException {
+    public void tearDown() {
         tearDownOsgiFramework(framework, storageTempDir);
     }
 
-    public static void tearDownOsgiFramework(Framework framework, File storageTempDir) throws BundleException, InterruptedException, IOException {
+    private static void tearDownOsgiFramework(Framework framework, File storageTempDir) {
         EmbeddedFelixFramework.stopFramework(framework);
-        framework = null;
-        if (storageTempDir != null) {
-            try {
-                FileUtils.deleteDirectory(storageTempDir);
-            } catch (IOException e) {
-                log.warn(e.getMessage());
-            }
-            storageTempDir = null;
-        }
+        FileUtil.deleteDirectory(storageTempDir);
     }
 
     @Test


### PR DESCRIPTION
fixes some of the tests in obvious ways, changes how overwritten keys are evaluated and some of the coercion logic.  also changes serialization of config keys not to write very common default values.  more detail in individual commits.

merges master, so ignore all the commits before 24 Nov